### PR TITLE
fix(testability): fix type error in getAllAngularTestability (dart)

### DIFF
--- a/modules/angular2/src/core/testability/get_testability.dart
+++ b/modules/angular2/src/core/testability/get_testability.dart
@@ -97,7 +97,7 @@ class GetTestability {
     });
     js.context['getAllAngularTestabilities'] = _jsify(() {
       List<Testability> testabilities = registry.getAllTestabilities();
-      List<PublicTestability> publicTestabilities = testabilities
+      var publicTestabilities = testabilities
           .map((testability) => new PublicTestability(testability));
       return _jsify(publicTestabilities);
     });


### PR DESCRIPTION
This fixes the following type error that is thrown when calling getAllAngularTestability() while running Dartium in checked mode:

type 'MappedListIterable' is not a subtype of type 'List<PublicTestability>' of 'publicTestabilities'.
#0      GetTestability.addToWindow.<anonymous closure> (package:angular2/src/core/testability/get_testability.dart:92:12)
#1      Function._apply (dart:core-patch/function_patch.dart:7)
#2      Function.apply (dart:core-patch/function_patch.dart:28)
#3      __invokeFn (package:angular2/src/core/testability/get_testability.dart:26:26)
#4      _jsFunction.<anonymous closure> (package:angular2/src/core/testability/get_testability.dart:15:12)
